### PR TITLE
chore: rename from starbase to canonical-sphinx

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -47,7 +47,7 @@ jobs:
   unit:
     strategy:
       matrix:
-        platform: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-latest]
+        platform: [ubuntu-20.04, ubuntu-22.04, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
   integration:
     strategy:
       matrix:
-        platform: [ubuntu-20.04, ubuntu-22.04, windows-latest, macos-latest]
+        platform: [ubuntu-20.04, ubuntu-22.04, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,9 @@ repos:
       - id: check-toml
       - id: fix-byte-order-marker
       - id: mixed-line-ending
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     # renovate: datasource=pypi;depName=ruff
-    rev: "v0.0.267"
+    rev: "v0.1.15"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -1,8 +1,8 @@
-*********
-Starcraft
-*********
+****************
+canonical-sphinx
+****************
 
-Welcome to Starcraft! We hope this document helps you get started. Before
+Welcome to canonical-sphinx! We hope this document helps you get started. Before
 contributing any code, please sign the `Canonical contributor licence
 agreement`_.
 

--- a/README.rst
+++ b/README.rst
@@ -1,14 +1,12 @@
-********
-starbase
-********
+****************
+canonical-sphinx
+****************
 
-A base repository for Starcraft projects.
+Extension and theme to create great Canonical-branded documentation.
 
 Description
 -----------
-This project is designed to act as the basis for any future starcraft projects
-as well as a testbed for any tooling changes we want to make before merging
-them into other projects.
+TODO
 
 Structure
 ---------
@@ -18,19 +16,6 @@ How to migrate existing projects
 --------------------------------
 TODO
 
-How to create a new project
----------------------------
-[TODO: Make this a template repository.]
-
-#. `Use this template`_ to create your repository.
-#. Ensure the ``LICENSE`` file represents the current best practices from the
-   Canonical legal team for the specific project you intend to release. (LGPL v3
-   for libraries, GPL v3 for applications.)
-#. Rename any files or directories and ensure references are updated.
-#. Replace any appropriate ``starcraft`` references with the appropriate name.
-#. Put correct contact information into CODE_OF_CONDUCT.md
-#. Write a new README
-#. Import your documentation to ReadTheDocs_.
 
 .. _EditorConfig: https://editorconfig.org/
 .. _pre-commit: https://pre-commit.com/

--- a/canonical_sphinx/__init__.py
+++ b/canonical_sphinx/__init__.py
@@ -1,6 +1,6 @@
-# This file is part of starcraft.
+# This file is part of canonical-sphinx.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 3, as published
@@ -13,7 +13,7 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Starcraft package demo."""
+"""Sphinx configuration, extension and theme for Canonical documentation."""
 from typing import List, Optional, Any
 
 try:
@@ -22,7 +22,7 @@ except ImportError:  # pragma: no cover
     from importlib.metadata import version, PackageNotFoundError
 
     try:
-        __version__ = version("starcraft")
+        __version__ = version("canonical-sphinx")
     except PackageNotFoundError:
         __version__ = "dev"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,8 +6,8 @@
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
-project = "starcraft"
-copyright = "2023, Canonical"
+project = "canonical-sphinx"
+copyright = "2024, Canonical"
 author = "Canonical"
 
 # region General configuration
@@ -57,6 +57,6 @@ always_document_param_types = True
 
 # Github config
 github_username = "canonical"
-github_repository = "starcraft-base"
+github_repository = "canonical-sphinx"
 
 # endregion

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "starcraft"
+name = "canonical-sphinx"
 dynamic = ["version", "readme"]
 dependencies = [
 
@@ -13,7 +13,7 @@ classifiers = [
 requires-python = ">=3.8"
 
 [project.scripts]
-starcraft-hello = "starcraft:hello"
+canonical-sphinx-hello = "canonical_sphinx:hello"
 
 [project.optional-dependencies]
 dev = [
@@ -55,7 +55,7 @@ build-backend = "setuptools.build_meta"
 readme = {file = "README.rst"}
 
 [tool.setuptools_scm]
-write_to = "starcraft/_version.py"
+write_to = "canonical_sphinx/_version.py"
 # the version comes from the latest annotated git tag formatted as 'X.Y.Z'
 # version scheme:
 #   - X.Y.Z.post<commits since tag>+g<hash>.d<%Y%m%d>
@@ -72,7 +72,7 @@ version_scheme = "post-release"
 git_describe_command = "git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'"
 
 [tool.setuptools.packages.find]
-include = ["*craft*"]
+include = ["canonical_sphinx"]
 namespaces = false
 
 [tool.black]
@@ -109,7 +109,7 @@ exclude_also = [
 ]
 
 [tool.pyright]
-strict = ["starcraft"]
+strict = ["canonical_sphinx"]
 pythonVersion = "3.8"
 pythonPlatform = "Linux"
 exclude = [
@@ -136,7 +136,7 @@ disallow_untyped_decorators = true
 disallow_any_generics = true
 
 [[tool.mypy.overrides]]
-module = ["starcraft.*"]
+module = ["canonical_sphinx.*"]
 disallow_untyped_defs = true
 no_implicit_optional = true
 
@@ -147,7 +147,7 @@ strict = false
 [tool.ruff]
 line-length = 88
 target-version = "py38"
-src = ["starcraft", "tests"]
+src = ["canonical_sphinx", "tests"]
 extend-exclude = [
     "docs",
     "__pycache__",
@@ -165,7 +165,7 @@ select = [  # Base linting rule selections.
     "D",  # Implement pydocstyle checking as well.
     "UP",  # Pyupgrade - note that some of are excluded below due to Python versions
     "YTT",  # flake8-2020: Misuse of `sys.version` and `sys.version_info`
-    "ANN",  # Type annotations.
+    "ANN",  # Type annotations
     "ASYNC",  # Catching blocking calls in async functions
     # flake8-bandit: security testing. https://docs.astral.sh/ruff/rules/#flake8-bandit-s
     # https://bandit.readthedocs.io/en/latest/plugins/index.html#complete-test-plugin-listing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,9 +26,9 @@ def project_main_module() -> types.ModuleType:
     """
     try:
         # This should be the project's main package; downstream projects must update this.
-        import starcraft
+        import canonical_sphinx
 
-        main_module = starcraft
+        main_module = canonical_sphinx
     except ImportError:
         pytest.fail(
             "Failed to import the project's main module: check if it needs updating",

--- a/tests/integration/starbase/test_init.py
+++ b/tests/integration/starbase/test_init.py
@@ -1,6 +1,6 @@
-# This file is part of starcraft.
+# This file is part of canonical-sphinx.
 #
-# Copyright 2023 Canonical Ltd.
+# Copyright 2024 Canonical Ltd.
 #
 # This program is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License version 3, as
@@ -13,13 +13,13 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Basic Starcraft package demo integration tests."""
+"""Basic canonical-sphinx package demo integration tests."""
 import subprocess
 
 
 def test_cli():
     expected = "Hello *craft team!\n"
 
-    actual = subprocess.check_output(["starcraft-hello"], text=True)
+    actual = subprocess.check_output(["canonical-sphinx-hello"], text=True)
 
     assert expected == actual

--- a/tests/unit/starbase/test_init.py
+++ b/tests/unit/starbase/test_init.py
@@ -17,17 +17,17 @@
 # pyright: reportFunctionMemberAccess=false
 from unittest import mock
 
-import starcraft
+import canonical_sphinx
 
 
 def test_version():
-    assert starcraft.__version__ is not None
+    assert canonical_sphinx.__version__ is not None
 
 
 def test_hello(mocker):
     mocker.patch("builtins.print")
 
-    starcraft.hello()
+    canonical_sphinx.hello()
 
     print.assert_called_once_with("Hello *craft team!")
 
@@ -35,7 +35,7 @@ def test_hello(mocker):
 def test_hello_people(mocker):
     mocker.patch("builtins.print")
 
-    starcraft.hello(["people"])
+    canonical_sphinx.hello(["people"])
 
     print.assert_has_calls(
         [

--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,6 @@ set_env =
     COVERAGE_FILE={env_tmp_dir}/.coverage_{env_name}
 pass_env =
     CI
-    CRAFT_*
     PYTEST_ADDOPTS
 
 [test]  # Base configuration for unit and integration tests
@@ -55,7 +54,7 @@ labels =
 change_dir =
     unit: tests/unit
     integration: tests/integration
-commands = pytest {tty:--color=yes} --cov={tox_root}/starcraft --cov-config={tox_root}/pyproject.toml --cov-report=xml:{tox_root}/results/coverage-{env_name}.xml --junit-xml={tox_root}/results/test-results-{env_name}.xml {posargs}
+commands = pytest {tty:--color=yes} --cov={tox_root}/canonical_sphinx --cov-config={tox_root}/pyproject.toml --cov-report=xml:{tox_root}/results/coverage-{env_name}.xml --junit-xml={tox_root}/results/test-results-{env_name}.xml {posargs}
 
 [lint]  # Standard linting configuration
 package = editable


### PR DESCRIPTION
This repository is originally based on the canonical/starbase template repo. This commit "rebrands" the various configuration files to refer to canonical-sphinx instead, with no functional changes (in that there is no functionality yet, other than a smoke-test "hello" function).

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

This first PR basically sets the "stage" for the upcoming work.
@ru-fu this is based on the template repo we use in the Starcraft team (canonical/starbase). It includes a whole bunch of stuff like tox, renovate, many linters, git-based versioning, etc. Please take a look around and let me know if you have any issues wit this!