### PR TITLE
chore: fix call to add_config_value()

### DIFF
--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -28,10 +28,10 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     app.add_config_value(
         "disable_feedback_button",
         default=False,
-        rebuild=True,
+        rebuild="env",
         types=bool,
     )
-    app.add_config_value("slug", default="", rebuild=True, types=str)
+    app.add_config_value("slug", default="", rebuild="env", types=str)
 
     # These are the extra extensions that we need.
     extra_extensions = [


### PR DESCRIPTION
The `rebuild` parameter used to be `bool | str`, but now is apparently just `str` (actually just a set of possible literals). Looking at the changeset in [1], it looks like `"env"` is equivalent to the old value of `True`.

1: https://github.com/sphinx-doc/sphinx/commit/19b2950511776f073300a218d6040a8a333c3b33

- [ ] Have you followed the guidelines for contributing?
- [ ] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
