### PR TITLE
__init__.py: mark all entrypoints as parallel safe

### DIFF
--- a/canonical_sphinx/__init__.py
+++ b/canonical_sphinx/__init__.py
@@ -14,7 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Sphinx configuration, extension and theme for Canonical documentation."""
-from typing import List, Optional, Any
+from typing import List, Optional, Any, Dict
 
 from sphinx.application import Sphinx
 
@@ -37,9 +37,13 @@ def hello(people: Optional[List[Any]] = None) -> None:
             print(f"Hello {person}!")
 
 
-def setup(app: Sphinx) -> None:
+def setup(app: Sphinx) -> Dict[str, Any]:
     """Configure the main extension and theme."""
     app.setup_extension("canonical_sphinx.config")
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }
 
 
 __all__ = ["__version__", "setup"]

--- a/canonical_sphinx/theme/__init__.py
+++ b/canonical_sphinx/theme/__init__.py
@@ -14,12 +14,16 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Sphinx theme for Canonical documentation."""
-
+from typing import Any, Dict
 from pathlib import Path
 
 from sphinx.application import Sphinx
 
 
-def setup(app: Sphinx) -> None:
+def setup(app: Sphinx) -> Dict[str, Any]:
     """Add "canonical_sphinx_theme" as a valid html theme."""
     app.add_html_theme("canonical_sphinx_theme", str(Path(__file__).parent))
+    return {
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/tests/unit/test_plugin_init.py
+++ b/tests/unit/test_plugin_init.py
@@ -1,0 +1,43 @@
+# Copyright 2023-2024 Canonical Ltd.
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License version 3, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranties of MERCHANTABILITY,
+# SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+from unittest import mock
+
+import canonical_sphinx
+
+
+def test_plugin_registration():
+    mocker = mock.Mock(canonical_sphinx.Sphinx)
+    config = canonical_sphinx.setup(mocker)
+    assert config["parallel_read_safe"] is True
+    assert config["parallel_write_safe"] is True
+    mocker.assert_has_calls([mock.call.setup_extension("canonical_sphinx.config")])
+
+
+def test_theme_plugin_registration():
+    from canonical_sphinx import theme
+
+    mocker = mock.Mock(canonical_sphinx.Sphinx)
+    with mock.patch.object(canonical_sphinx.theme, "__file__"):
+        config = theme.setup(mocker)
+        assert config["parallel_read_safe"] is True
+        assert config["parallel_write_safe"] is True
+        mocker.assert_has_calls(
+            [
+                mock.call.add_html_theme(
+                    "canonical_sphinx_theme",
+                    f"MagicMock{os.path.sep}__file__",
+                ),
+            ],
+        )


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `tox`?

-----

This pull request marks all the Sphinx plugin entrypoints as parallel safe to completely suppress the "extension does not declare if it is safe for parallel reading" warning message.