### PR TITLE
feat!: allows selective loading of extensions using optional dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ dmypy.json
 
 # Visual Studio Code
 .vscode/
+
+# asdf
+.tool-versions

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -24,4 +24,4 @@ python:
     - method: pip
       path: .
       extra_requirements:
-        - docs
+        - full

--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -175,10 +175,14 @@ def config_inited(_app: Sphinx, config: Any) -> None:  # noqa: ANN401
         ("github_issues", "enabled"),
         ("discourse", "https://discourse.ubuntu.com"),
         ("sequential_nav", "none"),
-        ("display_contributors", False),
+        ("display_contributors", True),
     ]
+
+    has_contributor_listing = "canonical.contributor-listing" in _app.extensions
 
     for value, default in values_and_defaults:
         html_context.setdefault(value, default)
+
+    html_context["has_contributor_listing"] = has_contributor_listing
 
     config.html_js_files.extend(html_js_files)

--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Sphinx configuration, extension and theme for Canonical documentation."""
+import importlib.util
 import os
 from pathlib import Path
 from typing import Any, Dict
@@ -33,8 +34,11 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     )
     app.add_config_value("slug", default="", rebuild="env", types=str)
 
-    # These are the extra extensions that we need.
     extra_extensions = [
+        "myst_parser",
+    ]
+
+    optional_packages = [
         "sphinx_design",
         "sphinx_tabs.tabs",
         "sphinx_reredirects",
@@ -45,10 +49,21 @@ def setup(app: Sphinx) -> Dict[str, Any]:
         "canonical.contributor-listing",
         "sphinx_copybutton",
         "sphinxext.opengraph",
-        "myst_parser",
         "sphinxcontrib.jquery",
         "notfound.extension",
     ]
+
+    for package in optional_packages:
+        try:
+            if importlib.util.find_spec(package) is not None:
+                extra_extensions.append(package)
+            else:
+                print(f"{package} not found.\n{package} will not be configured.")
+        except ModuleNotFoundError:  # noqa: PERF203
+            print(f"{package} not found.\n{package} will not be configured.")
+
+    # These are the extra extensions that we need.
+
     for ext in extra_extensions:
         app.setup_extension(ext)
 
@@ -160,7 +175,7 @@ def config_inited(_app: Sphinx, config: Any) -> None:  # noqa: ANN401
         ("github_issues", "enabled"),
         ("discourse", "https://discourse.ubuntu.com"),
         ("sequential_nav", "none"),
-        ("display_contributors", True),
+        ("display_contributors", False),
     ]
 
     for value, default in values_and_defaults:

--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -80,7 +80,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     }
 
 
-def config_inited(_app: Sphinx, config: Any) -> None:  # noqa: ANN401
+def config_inited(app: Sphinx, config: Any) -> None:  # noqa: ANN401
     """Read user-provided values and setup defaults."""
     config.myst_enable_extensions.update(["substitution", "deflist", "linkify"])
 
@@ -178,7 +178,7 @@ def config_inited(_app: Sphinx, config: Any) -> None:  # noqa: ANN401
         ("display_contributors", True),
     ]
 
-    has_contributor_listing = "canonical.contributor-listing" in _app.extensions
+    has_contributor_listing = "canonical.contributor-listing" in app.extensions
 
     for value, default in values_and_defaults:
         html_context.setdefault(value, default)

--- a/canonical_sphinx/theme/templates/footer.html
+++ b/canonical_sphinx/theme/templates/footer.html
@@ -71,7 +71,7 @@
     {%- endif %}
   </div>
   <div>
-   {% if display_contributors and pagename and page_source_suffix %}
+   {% if has_contributor_listing and display_contributors and pagename and page_source_suffix %}
        {% set contributors = get_contributors_for_file(pagename, page_source_suffix) %}
        {% if contributors %}
           {% if contributors | length > 1 %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,8 +11,6 @@ extensions = [
     "canonical_sphinx",
 ]
 
-show_authors = False
-
 html_context = {
     "product_page": "github.com/canonical/canonical-sphinx",
     "github_url": "https://github.com/canonical/canonical-sphinx",

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,26 +12,16 @@ StarCraft
    reference/index
    explanation/index
 
-.. grid:: 1 1 2 2
+.. list-table::
 
-   .. grid-item-card:: :ref:`Tutorial <tutorial>`
-
-      **Get started** with a hands-on introduction to Starcraft
-
-   .. grid-item-card:: :ref:`How-to guides <howto>`
-
-      **Step-by-step guides** covering key operations and common tasks
-
-.. grid:: 1 1 2 2
-   :reverse:
-
-   .. grid-item-card:: :ref:`Reference <reference>`
-
-      **Technical information** about Starcraft
-
-   .. grid-item-card:: :ref:`Explanation <explanation>`
-
-      **Discussion and clarification** of key topics
+    * - | :ref:`Tutorial <tutorial>`
+        | **Get started** with a hands-on introduction to Starcraft
+      - | :ref:`How-to guides <howto>`
+        | **Step-by-step guides** covering key operations and common tasks
+    * - | :ref:`Reference <reference>`
+        | **Technical information** about Starcraft
+      - | :ref:`Explanation <explanation>`
+        | **Discussion and clarification** of key topics
 
 Project and community
 =====================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,6 @@ requires-python = ">=3.8"
 [project.scripts]
 canonical-sphinx-hello = "canonical_sphinx:hello"
 
-# Moving extended version to optional install, but first iteration will need to use previous full install
-# Once deployed on pypi, can change canonical-sphinx==0.1.0 to canonical-sphinx[full]
 [project.optional-dependencies]
 full = [
     "linkify-it-py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ full = [
     "pyspelling",
 ]
 dev = [
-    "canonical-sphinx==0.1.0",
+    "canonical-sphinx[full]",
     "build",
     "coverage[toml]==7.6.1",
     "pytest==8.3.2",
@@ -41,19 +41,19 @@ dev = [
     "pytest-mock==3.14.0",
 ]
 lint = [
-    "canonical-sphinx==0.1.0",
+    "canonical-sphinx[full]",
     "black==24.8.0",
     "codespell[toml]==2.3.0",
     "ruff==0.5.7",
     "yamllint==1.35.1"
 ]
 types = [
-    "canonical-sphinx==0.1.0",
+    "canonical-sphinx[full]",
     "mypy[reports]==1.11.2",
     "pyright==1.1.378",
 ]
 docs = [
-    "canonical-sphinx==0.1.0",
+    "canonical-sphinx[full]",
     "sphinx-lint",
     "sphinx-autobuild<2024.2.5" # 2024.02.04 drops support for Python 3.8
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,8 @@ dynamic = ["version", "readme"]
 dependencies = [
     "sphinx>=7.1.2,<8",
     "furo",
-    "linkify-it-py",
-    "canonical-sphinx-extensions",
     "myst-parser",
     "pyspelling",
-    "sphinx-copybutton",
-    "sphinx-design",
-    "sphinx-notfound-page",
-    "sphinx-reredirects",
-    "sphinx-tabs",
-    "sphinxcontrib-jquery",
-    "sphinxext-opengraph",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -27,8 +18,22 @@ requires-python = ">=3.8"
 [project.scripts]
 canonical-sphinx-hello = "canonical_sphinx:hello"
 
+# Moving extended version to optional install, but first iteration will need to use previous full install
+# Once deployed on pypi, can change canonical-sphinx==0.1.0 to canonical-sphinx[full]
 [project.optional-dependencies]
+full = [
+    "linkify-it-py",
+    "canonical-sphinx-extensions",
+    "sphinx-copybutton",
+    "sphinx-design",
+    "sphinx-notfound-page",
+    "sphinx-reredirects",
+    "sphinx-tabs",
+    "sphinxcontrib-jquery",
+    "sphinxext-opengraph",
+]
 dev = [
+    "canonical-sphinx==0.1.0",
     "build",
     "coverage[toml]==7.6.1",
     "pytest==8.3.2",
@@ -36,16 +41,19 @@ dev = [
     "pytest-mock==3.14.0",
 ]
 lint = [
+    "canonical-sphinx==0.1.0",
     "black==24.8.0",
     "codespell[toml]==2.3.0",
     "ruff==0.5.7",
     "yamllint==1.35.1"
 ]
 types = [
+    "canonical-sphinx==0.1.0",
     "mypy[reports]==1.11.2",
     "pyright==1.1.378",
 ]
 docs = [
+    "canonical-sphinx==0.1.0",
     "sphinx-lint",
     "sphinx-autobuild<2024.2.5" # 2024.02.04 drops support for Python 3.8
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ dependencies = [
     "sphinx>=7.1.2,<8",
     "furo",
     "myst-parser",
-    "pyspelling",
 ]
 classifiers = [
     "Development Status :: 1 - Planning",
@@ -31,6 +30,7 @@ full = [
     "sphinx-tabs",
     "sphinxcontrib-jquery",
     "sphinxext-opengraph",
+    "pyspelling",
 ]
 dev = [
     "canonical-sphinx==0.1.0",

--- a/tox.ini
+++ b/tox.ini
@@ -149,3 +149,12 @@ labels = lint
 allowlist_externals = bash, xargs
 commands_pre = bash -c '{[lint-docs]find} > {env_tmp_dir}/lint_docs_files'
 commands = xargs --no-run-if-empty --arg-file {env_tmp_dir}/lint_docs_files sphinx-lint --max-line-length 80 --enable all {posargs}
+
+[testenv:docs-min]
+description = Test the minimal docs installation
+package = wheel
+no_package = false
+allowlist_externals = bash
+commands_pre = bash -c 'if [[ ! -e docs ]];then echo "No docs directory. Run `tox run -e sphinx-quickstart` to create one.;";return 1;fi'
+# "-W" is to treat warnings as errors
+commands = sphinx-build --keep-going {posargs:-b html} -W {tox_root}/docs {tox_root}/docs/_build

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ description = Run pre-commit on staged files or arbitrary pre-commit commands (t
 commands = pre-commit {posargs:run}
 
 [docs]  # Sphinx documentation configuration
-extras = docs
+extras = full, docs
 package = editable
 no_package = true
 env_dir = {work_dir}/docs

--- a/tox.ini
+++ b/tox.ini
@@ -115,7 +115,7 @@ description = Run pre-commit on staged files or arbitrary pre-commit commands (t
 commands = pre-commit {posargs:run}
 
 [docs]  # Sphinx documentation configuration
-extras = full, docs
+extras = docs
 package = editable
 no_package = true
 env_dir = {work_dir}/docs


### PR DESCRIPTION
BREAKING CHANGE: The [full] optional dependency needs to be loaded to support the functionality that was previously bundled into the extension. This is to support a minimal install.

Adds a `[full]` optional dependency in `pyproject.toml` that is the equivalent of the previous version.
Only sets up extensions that are installed and detected, so other subsets of deps can be supported if necessary.
Changes `display_contributors` default to `False` to support the minimal install option.
Adds a test for minimal install.