### PR TITLE
fix: change release-publish.yaml to find release tags

### DIFF
--- a/.github/workflows/release-publish.yaml
+++ b/.github/workflows/release-publish.yaml
@@ -20,7 +20,7 @@ jobs:
           # Note: we fetch the tags here instead of using actions/checkout's "fetch-tags"
           # because of https://github.com/actions/checkout/issues/1467
           git fetch --force --tags --depth 1
-          git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'
+          git describe --dirty --tags --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'
       - name: Setup Python
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
Fixes issue with release-publish.yaml.

```
   git describe --dirty --long --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*[^0-9.]*'
  shell: /usr/bin/bash -e {0}
From https://github.com/canonical/canonical-sphinx
 * [new branch]      main                -> origin/main
 * [new branch]      renovate/bugfixes   -> origin/renovate/bugfixes
 * [new branch]      renovate/doc-dependencies -> origin/renovate/doc-dependencies
 * [new branch]      renovate/major-doc-dependencies -> origin/renovate/major-doc-dependencies
 * [new branch]      renovate/setuptools-75.x -> origin/renovate/setuptools-75.x
 * [new branch]      renovate/tox-gh-1.x -> origin/renovate/tox-gh-1.x
 * [new tag]         0.1.0               -> 0.1.0
fatal: No annotated tags can describe 'c7149c3b1d76e4284be740f9ce5031e8f3cdf9ef'.
However, there were unannotated tags: try --tags.
```

I have verified adding `--tags` works (locally at least).