### PR TITLE
feat: add config value and changes to support epub build

### DIFF
--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -163,7 +163,7 @@ def config_inited(app: Sphinx, config: Any) -> None:  # noqa: ANN401
     # Issue: We don't have access to the builder here yet
     # Setting templates_path for epub makes the build fail
 
-    if config.epub_build == False:
+    if not config.epub_build:
         config.templates_path.append(str(theme_dir / "templates"))
         config.notfound_template = "404.html"
 

--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -61,6 +61,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
         try:
             if importlib.util.find_spec(package) is not None:
                 extra_extensions.append(package)
+                print(f"{package} found.\n{package} is now configured.")
             else:
                 print(f"{package} not found.\n{package} will not be configured.")
         except ModuleNotFoundError:  # noqa: PERF203
@@ -84,7 +85,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
     }
 
 
-def config_inited(app: Sphinx, config: Any) -> None:  # noqa: ANN401
+def config_inited(app: Sphinx, config: Any) -> None:  # noqa: ANN401 PLR0915
     """Read user-provided values and setup defaults."""
     config.myst_enable_extensions.update(["substitution", "deflist", "linkify"])
 

--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -34,6 +34,7 @@ def setup(app: Sphinx) -> Dict[str, Any]:
         types=bool,
     )
     app.add_config_value("slug", default="", rebuild="env", types=str)
+    app.add_config_value("epub_build", default=False, rebuild="env", types=bool)
 
     extra_extensions = [
         "myst_parser",
@@ -161,9 +162,10 @@ def config_inited(app: Sphinx, config: Any) -> None:  # noqa: ANN401
 
     # Issue: We don't have access to the builder here yet
     # Setting templates_path for epub makes the build fail
-    # if builder == "dirhtml" or builder == "html":
-    config.templates_path.append(str(theme_dir / "templates"))
-    config.notfound_template = "404.html"
+
+    if config.epub_build == False:
+        config.templates_path.append(str(theme_dir / "templates"))
+        config.notfound_template = "404.html"
 
     # PDF config
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ full = [
     "sphinxcontrib-jquery",
     "sphinxext-opengraph",
     "pyspelling",
+    "sphinx-autobuild",
 ]
 dev = [
     "canonical-sphinx[full]",
@@ -53,7 +54,6 @@ types = [
 docs = [
     "canonical-sphinx[full]",
     "sphinx-lint",
-    "sphinx-autobuild",
 ]
 
 [build-system]


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

Fixes #40 

If `epub_build` is `True` in config, prevents setting templates_path for epub builds.

I recommend adding to the Make target for epub with a `-D epub_build=True`. [RTD config](https://docs.readthedocs.io/en/stable/config-file/v2.html#build-jobs-build) will also need to be overwritten for the epub job.

This solution seems to be the best way to go, given the limitations of Sphinx's build order, and lack of builder context at the stage where this is needed.