### PR TITLE
fix: copyright year on PDF cover page template

### DIFF
--- a/canonical_sphinx/theme/PDF/latex_elements_template.txt
+++ b/canonical_sphinx/theme/PDF/latex_elements_template.txt
@@ -57,7 +57,7 @@
 }
 \fancypagestyle{titlepage}{%
     \fancyhf{}
-    \fancyfoot[L]{\footnotesize \textcolor{copyright}{© 2024 Canonical Ltd. All rights reserved.}}
+    \fancyfoot[L]{\footnotesize \textcolor{copyright}{© \the\year{} Canonical Ltd. All rights reserved.}}
 }
 \newcommand\sphinxbackoftitlepage{\thispagestyle{titlepage}}
 \titleformat{\chapter}[block]{\Huge \color{title} \bfseries\filright}{\thechapter .}{1.5ex}{}
@@ -93,7 +93,7 @@
 
 \begin{adjustwidth}{8cm}{0pt}
 \begin{tabularx}{0.5\textwidth}{ l l }
-    \textcolor{lightgray}{© 2024 Canonical Ltd.}  & \hspace{3cm} \\
+    \textcolor{lightgray}{© \the\year{} Canonical Ltd.}  & \hspace{3cm} \\
     \textcolor{lightgray}{All rights reserved.}   & \hspace{3cm} \\
                                                   & \hspace{3cm} \\
                                                   & \hspace{3cm} \\


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

## Description

- Replaced the hard-coded year number in latex template with the current year