### PR TITLE
feat: enable configuration options for PDF title and file name 

### DIFF
--- a/canonical_sphinx/theme/PDF/latex_elements_template.txt
+++ b/canonical_sphinx/theme/PDF/latex_elements_template.txt
@@ -17,6 +17,7 @@
 \usepackage{fancyhdr}
 \usepackage{graphicx}
 \usepackage{titlesec}
+\usepackage{titling}
 \usepackage{fontspec}
 \usepackage{tikz}
 \usepackage{changepage}
@@ -85,7 +86,7 @@
 
 \begin{adjustwidth}{8cm}{0pt}
 \begin{flushleft}
-    \huge \textcolor{black}{\textbf{}{\raggedright{$PROJECT}}}
+    \huge \textcolor{black}{\textbf{}{\raggedright{\thetitle}}}
 \end{flushleft}
 \end{adjustwidth}
 

--- a/example/conf.py
+++ b/example/conf.py
@@ -142,3 +142,14 @@ tags = []
 
 github_username = "example"
 github_repository = "project"
+
+# PDF LaTeX configuration: a list of tuples
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-latex_documents
+latex_documents = [(
+    master_doc, # startdocname, master_doc is the default project root index
+    "",         # targetname: file name of the output PDF. Whitespace is not allowed.
+    project,    # title: use empty string if you want to use the title of the master_doc
+    author,     # author
+    "manual",   # theme
+    False,      # toctree_only
+)]

--- a/example/conf.py
+++ b/example/conf.py
@@ -146,11 +146,13 @@ github_repository = "project"
 # PDF LaTeX configuration: a list of tuples
 # Removing the variable will revert to the default configuration for latexpdf.
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-latex_documents
-latex_documents = [(
-    "index", # startdocname, the project root index
-    f"{project.replace(' ', '_')}.tex", # targetname: file name of the output PDF. Whitespace is not allowed.
-    project,    # title: use empty string if you want to use the title of the master_doc
-    author,     # author
-    "manual",   # theme
-    False,      # toctree_only
-)]
+latex_documents = [
+    (
+        "index",  # startdocname, the project root index
+        f"{project.replace(' ', '_')}.tex",  # targetname: file name of the output PDF. Whitespace is not allowed.
+        project,  # title: use empty string if you want to use the title of the master_doc
+        author,  # author
+        "manual",  # theme
+        False,  # toctree_only
+    ),
+]

--- a/example/conf.py
+++ b/example/conf.py
@@ -144,10 +144,11 @@ github_username = "example"
 github_repository = "project"
 
 # PDF LaTeX configuration: a list of tuples
+# Removing the variable will revert to the default configuration for latexpdf.
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-latex_documents
 latex_documents = [(
-    master_doc, # startdocname, master_doc is the default project root index
-    "",         # targetname: file name of the output PDF. Whitespace is not allowed.
+    "index", # startdocname, the project root index
+    f"{project.replace(' ', '_')}.tex", # targetname: file name of the output PDF. Whitespace is not allowed.
     project,    # title: use empty string if you want to use the title of the master_doc
     author,     # author
     "manual",   # theme


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

## Description

The current latex template defined the `$PROJECT` value as the PDF document title, so it was not possible to pass a new title from the configuration file.

This PR changed the default title to `\thetitle` in Latex and leverages the Sphinx [`latex_documents`](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-latex_documents) configuration variable to overwrite default values:
- if the`latex_documents`  variable is not defined, the default title and output filename are the same as before
- if the variable is defined (as provided in `example/conf.py`), new values are used

Usage and documentation link are added to the example configuration file.