### PR TITLE
Add custom edit button and remove links in footer

### DIFF
--- a/canonical_sphinx/theme/templates/components/edit-this-page.html
+++ b/canonical_sphinx/theme/templates/components/edit-this-page.html
@@ -1,0 +1,38 @@
+{% extends "furo/components/edit-this-page.html" %}
+
+{%- macro canonical_edit_button(url) -%}
+<div class="edit-this-page">
+  <a class="muted-link" href="{{ url }}" title="{{ _("Contribute to this page") }}">
+    <svg><use href="#svg-pencil"></use></svg>
+    <span class="visually-hidden">{{ _("Contribute to this page") }}</span>
+  </a>
+</div>
+{%- endmacro -%}
+
+{%- if repo_folder -%}
+  {%- set docs_dir = repo_folder.strip("/") -%}
+{%- else -%}
+  {%- set docs_dir = "docs" -%}
+{%- endif -%}
+
+{# Construct the links based on the domain. This could all be handled in config.py. #}
+{%- if pagename and page_source_suffix and theme_source_edit_link -%}
+  {%- if theme_source_edit_link.startswith("https://github.com") -%}
+    {%- set url = theme_source_edit_link + "/blob/" + build_branch + "/" + docs_dir+ "/" + pagename + page_source_suffix -%}
+  {%- elif theme_source_edit_link.startswith(
+      (
+        "https://launchpad.net",
+        "https://git.launchpad.net"
+      )
+    ) -%}
+    {%- set base_url = "https://git.launchpad.net/" -%}
+    {%- set repo_name = theme_source_edit_link.rstrip("/").rsplit("/",1)[1] -%}
+    {%- set url = base_url + repo_name  + "/tree/" + docs_dir + "/" + pagename + page_source_suffix + "?h=" + build_branch -%}
+  {%- else -%}
+    {{ warning("Unsupported repository for 'source_edit_link'") }}
+  {%- endif -%}
+{%- endif -%}
+
+{% block link_available -%}
+{{ canonical_edit_button(url) }}
+{%- endblock %}

--- a/canonical_sphinx/theme/templates/footer.html
+++ b/canonical_sphinx/theme/templates/footer.html
@@ -91,41 +91,5 @@
    {% endif %}
   </div>
   <div class="right-details">
-
-    {# mod: replaced RTD icons with our links #}
-
-    {% if discourse %}
-    <div class="ask-discourse">
-      <a class="muted-link" href="{{ discourse }}">Ask a question on Discourse</a>
-    </div>
-    {% endif %}
-
-    {% if mattermost %}
-    <div class="ask-mattermost">
-      <a class="muted-link" href="{{ mattermost }}">Ask a question on Mattermost</a>
-    </div>
-    {% endif %}
-
-    {% if matrix %}
-    <div class="ask-matrix">
-      <a class="muted-link" href="{{ matrix }}">Ask a question on Matrix</a>
-    </div>
-    {% endif %}
-
-    {% if github_url and github_version and github_folder %}
-
-    {% if github_issues %}
-    <div class="issue-github">
-      <a class="muted-link" href="{{ github_url }}/issues/new?title=doc%3A+ADD+A+TITLE&body=DESCRIBE+THE+ISSUE%0A%0A---%0ADocument: {{ pagename }}{{ page_source_suffix }}">Open a GitHub issue for this page</a>
-    </div>
-    {% endif %}
-
-    <div class="edit-github">
-      <a class="muted-link" href="{{ github_url }}/edit/{{ github_version }}{{ github_folder }}{{ pagename }}{{ page_source_suffix }}">Edit this page on GitHub</a>
-    </div>
-    {% endif %}
-
-
-    </div>
   </div>
 </div>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,5 +16,9 @@ html_context = {
     "github_url": "https://github.com/canonical/canonical-sphinx",
 }
 
+html_theme_options = {
+    "source_edit_link": "https://github.com/canonical/canonical-sphinx",
+}
+
 github_username = "canonical"
 github_repository = "canonical-sphinx"

--- a/example/conf.py
+++ b/example/conf.py
@@ -63,11 +63,11 @@ html_context = {
     "discourse": "https://discourse.example-project.com",
     # Change to the GitHub URL for your project
     "github_url": "https://github.com/example/project",
-    # Change to the branch for this version of the documentation
-    "github_version": "v9.9.9",
+    # Override to change the mainline branch to a different name
+    # "repo_default_branch": "main",
     # Change to the folder that contains the documentation
     # (usually "/" or "/docs/")
-    "github_folder": "/example/docs/",
+    "repo_folder": "/example/docs/",
     # Change to an empty value if your GitHub repo doesn't have issues enabled.
     # This will disable the feedback button and the issue link in the footer.
     "github_issues": "enabled",
@@ -77,6 +77,11 @@ html_context = {
     # Controls whether to display the contributors for each file
     "display_contributors": False,
 }
+
+# Add the link to the doc's source repo here. Enables the edit button.
+# html_theme_options = {
+#    "source_edit_link": "https://github.com/canonical/sphinx-docs-starter-pack",
+# }
 
 # If your project is on documentation.ubuntu.com, specify the project
 # slug (for example, "lxd") here.

--- a/tests/integration/test_canonical_sphinx.py
+++ b/tests/integration/test_canonical_sphinx.py
@@ -51,7 +51,7 @@ def test_canonical_sphinx(example_project):
 
     # Check various fields/elements on the generated html
     index = build_dir / "index.html"
-    soup = bs4.BeautifulSoup(index.read_text())
+    soup = bs4.BeautifulSoup(index.read_text(), features="lxml")
 
     # Document title
     assert soup.title.string == "Example Project Docs"
@@ -65,10 +65,10 @@ def test_canonical_sphinx(example_project):
     logo = soup.find("a", {"class": "p-logo"})
     assert logo.attrs["href"] == "https://github.com/example/project"
 
-    logo_img = logo.findChild("img")
+    logo_img = logo.find("img")
     assert logo_img.attrs["src"] == "_static/example-tag.png"
 
-    logo_text = logo.findChild("div").string.strip()
+    logo_text = logo.find("div").string.strip()
     assert logo_text == "Example Project"
 
     # Discourse link
@@ -77,17 +77,3 @@ def test_canonical_sphinx(example_project):
         {"href": "https://discourse.example-project.com"},
     ).string.strip()
     assert discourse_ref == "Discourse"
-
-    # Links to create issue and edit on Github
-    github_issue = soup.find("div", {"class": "issue-github"}).findChild("a")
-    assert github_issue["href"].startswith(
-        "https://github.com/example/project/issues/new?",
-    )
-    assert github_issue.string.strip() == "Open a GitHub issue for this page"
-
-    github_edit = soup.find("div", {"class": "edit-github"}).findChild("a")
-    expected_edit = (
-        "https://github.com/example/project/edit/v9.9.9/example/docs/index.rst"
-    )
-    assert github_edit["href"] == expected_edit
-    assert github_edit.string.strip() == "Edit this page on GitHub"


### PR DESCRIPTION
For https://github.com/canonical/canonical-sphinx/issues/69:

- Re-implement Furo's edit button to account for our needs.
  - If `html_theme_options.source_edit_link` is set in conf.py and points to a hosted Git repo, the edit button is enabled. The button uses the link in the `github_folder` (old) and `repo_folder` (new) settings.
  - GitHub and Launchpad links are supported.
  - Rename `github_folder` config setting to `repo_folder`.
  - Rename `github_version` config setting to `repo_default_branch`.
- Permanently disable the view button. If the config tries to configure the buttons with the `top_of_page_buttons` setting, the build raises an error.
- Since the view button is disabled, disable source file generation.

The edit button link is only completely accurate for _production builds_. Making it accurate across all environments is too complex for the scope of this work.

The branch name in the edit link depends on the environment:
- Local build → default branch name (`repo_default_branch`)
- PR build → default branch name
- Production build → RTD branch name

Bonus refactor work:

- Pass an explicit `Config` to the main app connection, which makes all changes to dictionary values type-correct. Credit to @lengau for the solution.
- Update some of the BeautifulSoup method calls.

Fixes https://github.com/canonical/canonical-sphinx/issues/56:

All links are accounted for in the **More resources** menu in the nav bar.



---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?
