### PR TITLE
Feat: add custom linebreak commands for code fonts to Latex template

### DIFF
--- a/canonical_sphinx/theme/PDF/latex_elements_template.txt
+++ b/canonical_sphinx/theme/PDF/latex_elements_template.txt
@@ -116,5 +116,25 @@
       };
       \end{tikzpicture}
     }
+
+% Define new commands for breakable characters
+\let\origus\_
+\newcommand\allowbreaksafterunderscoreinliterals {%
+  \def\_{\discretionary{\origus}{}{\origus}}% breaks after underscore_ in literals
+}%
+
+\let\orighyphenwithbraces\sphinxhyphen{}
+\newcommand\allowbreaksaftersphinxhypheninliterals {%
+  \def\sphinxhyphen{\discretionary{-}{}{-}}% breaks after \sphinxhyphen - in literals
+}%
+
+% Add to Sphinx literal environment
+\makeatletter
+\g@addto@macro\sphinx@literal@nolig@list{%
+  \allowbreaksafterunderscoreinliterals
+  \allowbreaksaftersphinxhypheninliterals
+}%
+\makeatother
+
 ''',
 }


### PR DESCRIPTION
Update the LaTeX PDF template file to support more breakable characters in Sphinx literal environments (code font).

## Implementation

* Added new commands to allow line-breaks after underscores and hyphens in literals, and integrate them into the Sphinx `literal` environment:
  * `\allowbreaksafterunderscoreinliterals` 
  * `\allowbreaksaftersphinxhypheninliterals` 
---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?
