### PR TITLE
fix: change white links to blue links for dark systems

### DIFF
--- a/canonical_sphinx/theme/static/furo_colors.css
+++ b/canonical_sphinx/theme/static/furo_colors.css
@@ -82,7 +82,6 @@ body {
             --color-admonition-title--important: #C7162B;
             --color-admonition-title--caution: #F99B11;
             --color-highlighted-background: #666;
-            --color-link: #F9FCFF;
             --color-version-popup: #F29879;
         }
     }


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This PR fixes an inconsistency between dark mode cases:

- System set to light mode, page set to dark mode - Unvisited links are blue
- System set to dark mode, page set to audo/dark - Unvisited links are white

In furo_colors.css, the `@media (prefers-color-scheme: dark)  body:not([data-theme="light"])` block set `--color-link`, whereas the `body[data-theme="dark"]` block didn't set this. I've removed `--color-link` so that the two blocks are identical.

This means that unvisited links will always be blue, regardless of the dark mode config.