### PR TITLE
fix: use correct styles when hovering over feedback button, project name, doc title

### DIFF
--- a/canonical_sphinx/theme/static/custom.css
+++ b/canonical_sphinx/theme/static/custom.css
@@ -344,6 +344,14 @@ details summary {
    opacity: 0;
 }
 
+/* For sidebar documentation title, match text color and underline color on hover */
+.sidebar-brand:hover {
+    text-decoration-color: var(--color-sidebar-brand-text);
+}
+.sidebar-brand:visited:hover {
+    text-decoration-color: var(--color-sidebar-brand-text);
+}
+
 /* Mimicking the 'Give feedback' button for UX consistency */
 .sidebar-search-container input[type=submit] {
     color: #FFFFFF;

--- a/canonical_sphinx/theme/static/github_issue_links.css
+++ b/canonical_sphinx/theme/static/github_issue_links.css
@@ -18,6 +18,10 @@
     color: #FFFFFF;
     text-decoration: underline;
 }
+.muted-link.github-issue-link:visited:hover {
+    color: #FFFFFF;
+    text-decoration: underline;
+}
 .github-issue-link:active {
     color: #FFFFFF;
     text-decoration: underline;

--- a/canonical_sphinx/theme/static/header.css
+++ b/canonical_sphinx/theme/static/header.css
@@ -14,11 +14,11 @@
 }
 
 .p-logo:hover {
-  text-decoration-color: white;
+  text-decoration: none;
 }
 
 .p-logo:visited:hover {
-  text-decoration-color: white;
+  text-decoration: none;
 }
 
 .p-logo-image {

--- a/canonical_sphinx/theme/static/header.css
+++ b/canonical_sphinx/theme/static/header.css
@@ -13,6 +13,14 @@
   text-decoration: none;
 }
 
+.p-logo:hover {
+  text-decoration-color: white;
+}
+
+.p-logo:visited:hover {
+  text-decoration-color: white;
+}
+
 .p-logo-image {
   height: 44px;
   padding-right: 10px;


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

This PR fixes the underline styles when hovering over:

- The project name in the black banner. No underline, to match ubuntu.com. Fixed in header.css
- The documentation title in the sidebar. Same underline color as the text. Fixed in custom.css
- The "Give feedback" button (for previously-visited links only). Same underline color as the text. Fixed in github_issue_links.css