### PR TITLE
Make the "Edit the page button" edit again

### DIFF
--- a/canonical_sphinx/theme/templates/components/edit-this-page.html
+++ b/canonical_sphinx/theme/templates/components/edit-this-page.html
@@ -21,7 +21,7 @@
 {# Construct the links based on the domain. This could all be handled in config.py. #}
 {%- if pagename and page_source_suffix and theme_source_edit_link -%}
   {%- if theme_source_edit_link.startswith("https://github.com") -%}
-    {%- set url = theme_source_edit_link + "/blob/" + build_branch + docs_dir + "/" + pagename + page_source_suffix -%}
+    {%- set url = theme_source_edit_link + "/edit/" + build_branch + docs_dir + "/" + pagename + page_source_suffix -%}
   {%- elif theme_source_edit_link.startswith(
       (
         "https://launchpad.net",


### PR DESCRIPTION
The pencil button (called "Contribute to this page" in GUI and "Edit the page" in theme components) opens a GitHub repo on the rendered preview tab. To actually start editing, we need to click on another pencil button on GitHub itself. This simple PR makes it so, that we don't need to click pencil buttons twice, leading directly to editing interface. I don't see any reason to see a GitHub preview first, as our RTD rendered page is the final form for viewing.

If, for any reason, we do need a GitHub preview to open first, I can add a config parameter for the theme.

- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----
