### PR TITLE
Fix: rendering of empty product page link in header template

### DIFF
--- a/canonical_sphinx/theme/templates/header.html
+++ b/canonical_sphinx/theme/templates/header.html
@@ -5,15 +5,25 @@
     <ul class="p-navigation__links" role="menu">
 
       <li>
+        {% if product_page %}
         <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
           <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
           <div class="p-logo-text p-heading--4">{{ project }}
           </div>
         </a>
+        {% else %}
+        <div class="p-logo">
+          <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
+          <div class="p-logo-text p-heading--4">{{ project }}
+          </div>
+        </div>
+        {% endif %}
       </li>
 
       <li class="nav-ubuntu-com">
+        {% if product_page %}
         <a href="https://{{ product_page }}" class="p-navigation__link">{{ product_page }}</a>
+        {% endif %}
       </li>
 
       <li>


### PR DESCRIPTION
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
(Resolves issue #72 and https://github.com/canonical/sphinx-docs-starter-pack/issues/339)

The `{{product_page}}` used in the header template header is defined in the HTML context dictionary within `conf.py`. Users can leave this value empty to indicate that there is no product link available; however, the template does not validate this during rendering. As a result, empty links are still rendered as clickable links, leading to the invalid URL `<a href="https://">`.

This PR adds a value check in the HTML header template, and removes the link if empty.

**Screenshots**

* **Before**: the empty link has a hover effect, and points to an invalid link `https://`
   ![image](https://github.com/user-attachments/assets/b38d5a98-6770-4f95-b73a-9067736004b6)
  ![image](https://github.com/user-attachments/assets/0ab9b3df-3d2f-4e6b-a5cf-b4b480305310)

*  **After**: link removed without changing the layout width
  ![image](https://github.com/user-attachments/assets/5a0f73f6-f496-4f4d-bf75-7143dc0dfae2)
  ![image](https://github.com/user-attachments/assets/d724ee6d-2ef6-40f7-b751-23b4d4f49953)


