### PR TITLE
Add ARIA role to the dropdown list

### DIFF
--- a/canonical_sphinx/theme/templates/header.html
+++ b/canonical_sphinx/theme/templates/header.html
@@ -26,28 +26,32 @@
         {% endif %}
       </li>
 
-      <li>
-        <a href="#" class="p-navigation__link nav-more-links">More resources</a>
-        <ul class="more-links-dropdown">
-
+      <li class="nav-dropdown">
+        <a href="#" class="p-navigation__link nav-more-links"
+           id="more-resources-toggle"
+           aria-haspopup="true"
+           aria-expanded="false">
+          More resources
+        </a>
+        <ul class="more-links-dropdown" aria-labelledby="more-resources-toggle">
           {% if discourse %}
           <li>
             <a href="{{ discourse }}" class="p-navigation__sub-link p-dropdown__link">Discourse</a>
           </li>
           {% endif %}
-
+      
           {% if mattermost %}
           <li>
             <a href="{{ mattermost }}" class="p-navigation__sub-link p-dropdown__link">Mattermost</a>
           </li>
           {% endif %}
-
+      
           {% if matrix %}
           <li>
             <a href="{{ matrix }}" class="p-navigation__sub-link p-dropdown__link">Matrix</a>
           </li>
           {% endif %}
-
+      
           {% if github_url %}
           <li>
             <a href="{{ github_url }}" class="p-navigation__sub-link p-dropdown__link">GitHub</a>


### PR DESCRIPTION
- [ ] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?

-----

I would love to follow the guidelines but I couldn't find them. :crying_cat_face: 

This PR gives the dropdown list in nav proper ARIA attributes, see [ARIA documentation](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-haspopup). I'm not sure if it's the correct solution so I'd appreciate feedback/correction on this.