### PR TITLE
fix: remove duplicate 404 text

### DIFF
--- a/canonical_sphinx/theme/templates/404.html
+++ b/canonical_sphinx/theme/templates/404.html
@@ -2,7 +2,6 @@
 
 {% block content -%}
 <section>
-  <h1>Page not found</h1>
   <div class="sd-container-fluid sd-sphinx-override sd-mb-4 docutils">
     <div class="sd-row sd-row-cols-1 sd-row-cols-xs-1 sd-row-cols-sm-1 sd-row-cols-md-2 sd-row-cols-lg-2 sd-g-5 sd-g-xs-5 sd-g-sm-5 sd-g-md-5 sd-g-lg-5 docutils">
       <div class="sd-col sd-d-flex-column docutils">


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [X] Have you successfully run `tox`?

-----

The body of the default [`notfound_context`](https://sphinx-notfound-page.readthedocs.io/en/latest/configuration.html#confval-notfound_context) already includes `<h1>Page not found</h1>`. This results in the text being duplicated in the rendered page.

<img width="855" height="435" alt="image" src="https://github.com/user-attachments/assets/0566b285-6c73-4de0-8452-a01f02989eab" />

An alternative fix for this would be to add `sphinx-notfound-page` as a Starter Pack dependency and update `conf.py` to include:

```
notfound_context = {
    'title': 'Page not found',
    'body': "Unfortunately we couldn't find the content you were looking for.",
}
```

That seems messy to me, as it would be the only theme component outside of this extension. It also requires a lot more conscious effort from the team.