### PR TITLE
fix: normalize admonition title background colors

### DIFF
--- a/canonical_sphinx/theme/static/custom.css
+++ b/canonical_sphinx/theme/static/custom.css
@@ -156,8 +156,8 @@ table.align-center {
     border-bottom: 1px solid #d9d9d9;
 }
 
-.admonition[class] > .admonition-title {
-    background-color: var(--color-background-primary);
+.admonition > .admonition-title {
+    background-color: var(--color-background-primary) !important;
 }
 
 


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----

Resolves https://github.com/canonical/canonical-sphinx/issues/110

With this change, all admonitions will have a consistent title background color. I took the following screenshot after consuming this branch in Snapcraft.

<img width="836" height="469" alt="image" src="https://github.com/user-attachments/assets/2727aa95-7865-4f4b-a721-4469ab8fb096" />

Though Ulwazi will soon supersede canonical-sphinx, I feel that this improvement will prove worthwhile in the meantime.