### PR TITLE
fix(style): Add CSS for inline code in dark mode

### DIFF
--- a/canonical_sphinx/theme/static/furo_colors.css
+++ b/canonical_sphinx/theme/static/furo_colors.css
@@ -44,7 +44,7 @@ body {
         --color-background-hover: #666;
         --color-brand-primary: #fff;
         --color-brand-content: #69C;
-	--color-inline-code-background: var(--color-code-background);
+	    --color-inline-code-background: var(--color-code-background);
         --color-sidebar-link-text: #f7f7f7;
         --color-sidebar-item-background--current: #666;
         --color-sidebar-item-background--hover: #333;
@@ -71,7 +71,7 @@ body {
             --color-background-hover: #666;
             --color-brand-primary: #fff;
             --color-brand-content: #69C;
-	    --color-inline-code-background: var(--color-code-background);
+	        --color-inline-code-background: var(--color-code-background);
             --color-sidebar-link-text: #f7f7f7;
             --color-sidebar-item-background--current: #666;
             --color-sidebar-item-background--hover: #333;

--- a/canonical_sphinx/theme/static/furo_colors.css
+++ b/canonical_sphinx/theme/static/furo_colors.css
@@ -44,6 +44,7 @@ body {
         --color-background-hover: #666;
         --color-brand-primary: #fff;
         --color-brand-content: #69C;
+	--color-inline-code-background: rgba(255,255,255,.08);
         --color-sidebar-link-text: #f7f7f7;
         --color-sidebar-item-background--current: #666;
         --color-sidebar-item-background--hover: #333;
@@ -70,6 +71,7 @@ body {
             --color-background-hover: #666;
             --color-brand-primary: #fff;
             --color-brand-content: #69C;
+	    --color-inline-code-background: rgba(255,255,255,.08);
             --color-sidebar-link-text: #f7f7f7;
             --color-sidebar-item-background--current: #666;
             --color-sidebar-item-background--hover: #333;

--- a/canonical_sphinx/theme/static/furo_colors.css
+++ b/canonical_sphinx/theme/static/furo_colors.css
@@ -13,7 +13,7 @@ body {
     --color-brand-content: #06C;
     --color-api-background: var(--color-code-background);
     --color-api-background--hover: var(--color-sidebar-item-background--hover);
-    --color-inline-code-background: rgba(0,0,0,.03);
+    --color-inline-code-background: var(--color-code-background);
     --color-sidebar-link-text: #111;
     --color-sidebar-item-background--current: #ebebeb;
     --color-sidebar-item-background--hover: #f2f2f2;
@@ -44,7 +44,7 @@ body {
         --color-background-hover: #666;
         --color-brand-primary: #fff;
         --color-brand-content: #69C;
-	--color-inline-code-background: rgba(255,255,255,.08);
+	--color-inline-code-background: var(--color-code-background);
         --color-sidebar-link-text: #f7f7f7;
         --color-sidebar-item-background--current: #666;
         --color-sidebar-item-background--hover: #333;
@@ -71,7 +71,7 @@ body {
             --color-background-hover: #666;
             --color-brand-primary: #fff;
             --color-brand-content: #69C;
-	    --color-inline-code-background: rgba(255,255,255,.08);
+	    --color-inline-code-background: var(--color-code-background);
             --color-sidebar-link-text: #f7f7f7;
             --color-sidebar-item-background--current: #666;
             --color-sidebar-item-background--hover: #333;


### PR DESCRIPTION
# Description 
Currently we do not have any CSS for inline code in dark mode. It therefore picks up the default light mode CSS which is not visible in dark mode. I have used .08 as the transparency level rather than 0.03 like the light mode as I think it is very hard to differentiate 0.03 in dark mode.

I was unsure how to get the project to point to the local canonical-sphinx so I mocked it up in my browser below. 
Before:
<img width="953" height="116" alt="image" src="https://github.com/user-attachments/assets/3dc89e78-979e-4df6-949a-a72049e1e8e1" />


After:
<img width="953" height="116" alt="image" src="https://github.com/user-attachments/assets/64e7eae2-1b88-482f-8280-f7c45e79d97f" />

# Issue
Addresses: Issue #65 


- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`? - This would not run locally but I believe that is a versioning issue on my end

-----
