### PR TITLE
fix(style): Update h3 top margin to 1.5rem

### DIFF
--- a/canonical_sphinx/theme/static/custom.css
+++ b/canonical_sphinx/theme/static/custom.css
@@ -101,8 +101,12 @@ html {
 }
 
 /* heading specific definitions */
-h1, h3, h5 { font-weight: 550; }
+h1, h5 { font-weight: 550; }
 h2 { font-weight: 180; }
+h3 { 
+    font-weight: 550;
+    margin-top: 1.5rem;
+}
 h4 { font-weight: 275; }
 
 /* bold */

--- a/canonical_sphinx/theme/static/custom.css
+++ b/canonical_sphinx/theme/static/custom.css
@@ -101,12 +101,9 @@ html {
 }
 
 /* heading specific definitions */
-h1, h5 { font-weight: 550; }
+h1, h3, h5 { font-weight: 550; }
 h2 { font-weight: 180; }
-h3 { 
-    font-weight: 550;
-    margin-top: 1.5rem;
-}
+h3 { margin-top: 1.5rem; }
 h4 { font-weight: 275; }
 
 /* bold */


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [ ] Have you successfully run `tox`?

-----
Widens the top margin for level-3 headings.

Resolves https://github.com/canonical/canonical-sphinx/issues/73.