### PR TITLE
style: partition stacked TOCs

### DIFF
--- a/canonical_sphinx/theme/static/custom.css
+++ b/canonical_sphinx/theme/static/custom.css
@@ -374,9 +374,16 @@ details summary {
 }
 
 /* Partition stacked TOCs */
-.sidebar-tree > ul:not(:first-child) {
+.sidebar-tree > ul + ul {
     margin-top: 1em;
     padding-top: 1em;
+    border-top: 1px solid var(--color-background-border);
+}
+
+/* Partition captioned TOCs */
+.sidebar-tree > p.caption {
+    margin-top: 2em !important;
+    padding-top: 2em !important;
     border-top: 1px solid var(--color-background-border);
 }
 

--- a/canonical_sphinx/theme/static/custom.css
+++ b/canonical_sphinx/theme/static/custom.css
@@ -373,6 +373,13 @@ details summary {
     text-decoration: underline;
 }
 
+/* Partition stacked TOCs */
+.sidebar-tree > ul:not(:first-child) {
+    margin-top: 1em;
+    padding-top: 1em;
+    border-top: 1px solid var(--color-background-border);
+}
+
 /* Make inline code the same size as code blocks */
 p code.literal {
     border: 0;


### PR DESCRIPTION
Provide visual separatation for stacked TOCs, like this:

```rest
.. toctree::
    :hidden:

    tutorials/index
    how-to/index
    reference/index
    explanation/index

.. toctree::
    :hidden:

    release-notes/index
    contribute/index
```

Preview:

<img width="33%" alt="image" src="https://github.com/user-attachments/assets/c1fdddf4-3061-4e64-bf49-1e015fc8018f" />

Resolves #117.

---
- [x] Have you followed the guidelines for contributing?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `tox`?