### PR TITLE
feat: make feedback link configurable

### DIFF
--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -220,7 +220,9 @@ def config_inited(app: Sphinx, config: SphinxConfig) -> None:  # noqa: PLR0915, 
     with Path.open(theme_dir / "PDF/latex_elements_template.txt", "r+") as file:
         config.latex_config = file.read()
 
-    if config.latex_elements == {}:  # pyright: ignore [reportUnnecessaryComparison] type: # ignore[comparison-overlap]
+    if (
+        config.latex_elements == {}
+    ):  # pyright: ignore [reportUnnecessaryComparison] type: # ignore[comparison-overlap]
         config.latex_elements = ast.literal_eval(config.latex_config)
 
     html_context = config.html_context

--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Sphinx configuration, extension and theme for Canonical documentation."""
+
 import ast
 import importlib.util
 import os
@@ -219,9 +220,7 @@ def config_inited(app: Sphinx, config: SphinxConfig) -> None:  # noqa: PLR0915, 
     with Path.open(theme_dir / "PDF/latex_elements_template.txt", "r+") as file:
         config.latex_config = file.read()
 
-    if (
-        config.latex_elements == {}
-    ):  # pyright: ignore [reportUnnecessaryComparison] type: # ignore[comparison-overlap]
+    if config.latex_elements == {}:  # pyright: ignore [reportUnnecessaryComparison] type: # ignore[comparison-overlap]
         config.latex_elements = ast.literal_eval(config.latex_config)
 
     html_context = config.html_context
@@ -236,6 +235,7 @@ def config_inited(app: Sphinx, config: SphinxConfig) -> None:  # noqa: PLR0915, 
         ("discourse", "https://discourse.ubuntu.com"),
         ("sequential_nav", "none"),
         ("display_contributors", True),
+        ("feedback_link", ""),
     ]
 
     has_contributor_listing = "canonical.contributor-listing" in app.extensions
@@ -243,7 +243,9 @@ def config_inited(app: Sphinx, config: SphinxConfig) -> None:  # noqa: PLR0915, 
     for value, default in values_and_defaults:
         html_context.setdefault(value, default)
 
-    if html_context.get("github_issues") and not disable_feedback_button:
+    if (
+        html_context.get("github_issues") or html_context.get("feedback_link")
+    ) and not disable_feedback_button:
         html_js_files.append("github_issue_links.js")
 
     html_context["has_contributor_listing"] = has_contributor_listing

--- a/canonical_sphinx/config.py
+++ b/canonical_sphinx/config.py
@@ -290,7 +290,7 @@ def config_inited(app: Sphinx, config: SphinxConfig) -> None:  # noqa: PLR0915, 
     # Inject branch name into context
     branch = config.html_context["repo_default_branch"]
 
-    if "READTHEDOCS" in os.environ:  # noqa: SIM102; `in` is orthogonal to `!=`
+    if "READTHEDOCS" in os.environ:  # noqa: SIM102
         # Skip PR builds because ReadTheDocs can't read the target branch from
         # GitHub actions
         if os.environ["READTHEDOCS_VERSION_TYPE"] != "external":

--- a/canonical_sphinx/theme/static/github_issue_links.js
+++ b/canonical_sphinx/theme/static/github_issue_links.js
@@ -24,6 +24,9 @@ window.onload = function() {
         + `*Reported+from%3A+${location.href}*`
     );
     link.target = "_blank";
+    if (feedback_link) {
+        link.href = feedback_link;
+    }
 
     const div = document.createElement("div");
     div.classList.add("github-issue-link-container");

--- a/canonical_sphinx/theme/static/github_issue_links.js
+++ b/canonical_sphinx/theme/static/github_issue_links.js
@@ -24,6 +24,7 @@ window.onload = function() {
         + `*Reported+from%3A+${location.href}*`
     );
     link.target = "_blank";
+    
     if (feedback_link) {
         link.href = feedback_link;
     }

--- a/canonical_sphinx/theme/templates/base.html
+++ b/canonical_sphinx/theme/templates/base.html
@@ -3,6 +3,7 @@
 {% block theme_scripts %}
 <script>
   const github_url = "{{ github_url }}";
+  const feedback_link = "{{ feedback_link }}";
 </script>
 {% endblock theme_scripts %}
 


### PR DESCRIPTION
- [X] Have you followed the guidelines for contributing?
- [X] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
~~Have you successfully run `tox`?~~ Failures unrelated

-----

Adds a `feedback_link` variable to the base HTML template. If set, this link takes precedence over the link composed with the value of `github_url`.

Resolves https://github.com/canonical/canonical-sphinx/issues/51.